### PR TITLE
Fix variable access warnings and an error

### DIFF
--- a/templates/etc/revaliases.erb
+++ b/templates/etc/revaliases.erb
@@ -2,7 +2,7 @@
 #
 # sSMTP revaliases configuation file
 #
-# Managed: Puppet <%= puppetversion %> on <%= puppetmaster %>
+# Managed: Puppet <%= @puppetversion %><% if @puppetmaster -%> on <%= @puppetmaster %><% end %>
 #
 # Format:  local_account:outgoing_address:mailhub
 #

--- a/templates/etc/ssmtp.conf.erb
+++ b/templates/etc/ssmtp.conf.erb
@@ -2,7 +2,7 @@
 #
 # sSMTP configuation file
 #
-# Managed: Puppet <%= puppetversion %> on <%= puppetmaster %>
+# Managed: Puppet <%= @puppetversion %><% if @puppetmaster -%> on <%= @puppetmaster %><% end %>
 #
 
 root=<%= scope.lookupvar('ssmtp::rootEmail') %>


### PR DESCRIPTION
When I run this module on my puppet nodes (v3.3.2), I get the following error:

```
Error: Failed to parse template ssmtp/etc/ssmtp.conf.erb:
  Filepath: /usr/lib/ruby/site_ruby/1.8/puppet/parser/templatewrapper.rb
  Line: 81
  Detail: Could not find value for 'puppetmaster' at /tmp/vagrant-puppet/modules-0/ssmtp/templates/etc/ssmtp.conf.erb:5
 at /tmp/vagrant-puppet/modules-0/ssmtp/manifests/config.pp:23 on node web.the-jci.org
```

I don't know why "puppetmaster" isn't defined for my servers, but I fixed the error by simply wrapping the references to puppetmaster inside an "if" block.

I also got the following warning, which I fixed as well:

```
Warning: Variable access via 'puppetversion' is deprecated. Use '@puppetversion' instead. template[/tmp/vagrant-puppet/modules-0/ssmtp/templates/etc/ssmtp.conf.erb]:5
   (at /tmp/vagrant-puppet/modules-0/ssmtp/templates/etc/ssmtp.conf.erb:5:in `result')
```
