### PR TITLE
Support more config params

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,22 @@
 # Sample Usage: include ssmtp::config
 #
 class ssmtp::config {
+  # make parameters available in local scope for usage in templates
+  $defaultMta       = $ssmtp::defaultMta
+  $rootEmail        = $ssmtp::rootEmail
+  $mailHub          = $ssmtp::mailHub
+  $revaliases       = $ssmtp::revaliases
+  $fromlineoverride = $ssmtp::fromlineoverride
+  $authuser         = $ssmtp::authuser
+  $authpass         = $ssmtp::authpass
+  $authmethod       = $ssmtp::authmethod
+  $usetls           = $ssmtp::usetls
+  $usestarttls      = $ssmtp::usestarttls
+  $tlscert          = $ssmtp::tlscert
+  $tlskey           = $ssmtp::tlskey
+  $tlscafile        = $ssmtp::tlscafile
+  $tlscadir         = $ssmtp::tlscadir
+
 
   # sSMTP configuration
   file {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,17 +32,17 @@ class ssmtp::config {
   file {
     $ssmtp::params::configSsmtpConf:
       ensure  => present,
-      mode    => '0644',
-      owner   => root,
-      group   => root,
+      mode    => '0640',
+      owner   => 'root',
+      group   => 'mail',
       path    => $ssmtp::params::configSsmtpConf,
       content => template($ssmtp::params::configSsmtpConfTemplate);
 
     $ssmtp::params::configRevaliasesConf:
       ensure  => present,
       mode    => '0644',
-      owner   => root,
-      group   => root,
+      owner   => 'root',
+      group   => 'root',
       path    => $ssmtp::params::configRevaliasesConf,
       content => template($ssmtp::params::configRevaliasesConfTemplate);
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,8 +15,38 @@
 # [*mailHub*]
 #   server that handle outgoing mail
 #
+# [fromlineoverride]
+#   Default: YES
+#
 # [*revaliases*]
 #   Array of reverse aliases
+#
+# [authuser]
+#   ssmtp.conf parameter. see man 5 ssmtp.conf
+#
+# [authpass]
+#   ssmtp.conf parameter. see man 5 ssmtp.conf
+#
+# [authmethod]
+#   ssmtp.conf parameter. see man 5 ssmtp.conf
+#
+# [tlscert]
+#   ssmtp.conf parameter. see man 5 ssmtp.conf
+#
+# [tlskey]
+#   ssmtp.conf parameter. see man 5 ssmtp.conf
+#
+# [authuser]
+#   ssmtp.conf parameter. see man 5 ssmtp.conf
+#
+# [tlscafile]
+#   ssmtp.conf parameter. see man 5 ssmtp.conf
+#
+# [tlscadir]
+#   ssmtp.conf parameter. see man 5 ssmtp.conf
+#
+# [require_yum] (bool, default=true)
+#   It set to false module yum will not be required.
 #
 # === Variables
 #
@@ -29,19 +59,35 @@
 #
 # === Authors
 #
-# Author Thomas Bendler <project@bendler-net.de>
+# Thomas Bendler <project@bendler-net.de>
+# Thomas Mueller <mueller@puzzle.ch>
 #
 # === Copyright
 #
-# Copyright 2014 Thomas Bendler
+# Copyright 2015 Thomas Bendler
 #
 class ssmtp (
-  $defaultMta = $ssmtp::params::defaultMta,
-  $rootEmail  = $ssmtp::params::rootEmail,
-  $mailHub    = $ssmtp::params::mailHub,
-  $revaliases = $ssmtp::params::revaliases) inherits ssmtp::params {
-  # Require class yum to have the relevant repositories in place
-  require yum
+  $defaultMta       = $ssmtp::params::defaultMta,
+  $rootEmail        = $ssmtp::params::rootEmail,
+  $mailHub          = $ssmtp::params::mailHub,
+  $revaliases       = $ssmtp::params::revaliases,
+  $fromlineoverride = $ssmtp::params::fromlineoverride,
+  $authuser         = undef,
+  $authpass         = undef,
+  $authmethod       = undef,
+  $usetls           = undef,
+  $usestarttls      = undef,
+  $tlscert          = undef,
+  $tlskey           = undef,
+  $tlscafile        = undef,
+  $tlscadir         = undef,
+  $require_yum      = true,
+) inherits ssmtp::params {
+
+  if str2bool($require_yum) {
+    # Require class yum to have the relevant repositories in place
+    require yum
+  }
 
   # Start workflow
   if $ssmtp::params::linux {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,8 +32,9 @@ class ssmtp::params {
   }
 
   # sSMTP definitions
-  $defaultMta = 'none'
-  $rootEmail  = 'john.doe@example.local'
-  $mailHub    = 'mail.example.local'
-  $revaliases = ['# Custom revaliases']
+  $defaultMta       = 'none'
+  $rootEmail        = 'john.doe@example.local'
+  $mailHub          = 'mail.example.local'
+  $revaliases       = ['# Custom revaliases']
+  $fromlineoverride = 'YES'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "thbe-ssmtp",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "author": "thbe",
   "summary": "sSMTP management module",
   "license": "GPL-3.0",
@@ -12,6 +12,7 @@
     { "operatingsystem": "CentOS", "operatingsystemrelease": [ "6.0", "7.0" ] }
   ],
   "dependencies": [
-    { "name": "thbe-yum", "version_range": ">= 0.4.10" }
+    { "name": "thbe-yum", "version_range": ">= 0.4.10" },
+    { "name": "puppetlabs-stdlib", "version_range": ">= 1.0.0" }
   ]
 }

--- a/templates/etc/ssmtp.conf.erb
+++ b/templates/etc/ssmtp.conf.erb
@@ -8,4 +8,32 @@
 root=<%= @rootEmail %>
 mailhub=<%= @mailHub %>
 
-FromLineOverride=YES
+FromLineOverride=<%= @fromlineoverride %>
+
+<% if @authuser -%>
+AuthUser=<%= @authuser %>
+<% end -%>
+<%- if @authpass -%>
+AuthPass=<%= @authpass %>
+<% end -%>
+<% if @authmethod -%>
+AuthMethod=<%= @authmethod %>
+<% end -%>
+<% if @usetls -%>
+UseTLS=<%= @usetls %>
+<% end -%>
+<% if @usestartls -%>
+UseSTARTTLS=<%= @starttls %>
+<% end -%>
+<% if @tlscert -%>
+TLSCert=<%= @tlscert %>
+<% end -%>
+<% if @tlskey -%>
+TLSKey=<%= @tlskey %>
+<% end -%>
+<% if @tlscafile -%>
+TLS_CA_File=<%= @tlscafile %>
+<% end -%>
+<% if @tlscadir -%>
+TLS_CA_Dir=<%= @tlscadir %>
+<% end -%>


### PR DESCRIPTION
Add ssmpt.conf AuthUser, AuthPass, AuthMethod, TLSCert, TLSKey, TLS_CA_File and TLS_CA_Dir as class parameters.

Add a new param require_yum to have the ability to disable the "require yum" as needed.

The ssmtp.conf file should not be world-readable as it could contain credentils.

Tested on CentOS 6 with puppet 4 (puppet-agent AIO):

echo "class { ::ssmtp: require_yum => false, authuser => "authuser", authpass=>"authpass", authmethod=>"authemthod", tlscert=>"tlscert", tlskey=>"tlskey", tlscafile=>"tlscafile", tlscadir=>"tlscadir" }" | /opt/puppetlabs/bin/puppet apply
