### PR TITLE
Lintian fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ can use:
 
 ```puppet
 class { '::ssmtp':
-  mailHub => 'mail.example.local',
+  mailhub => 'mail.example.local',
 }
 ```
 
@@ -62,8 +62,8 @@ include '::ssmtp'
 
 ```puppet
 class { '::ssmtp':
-  mailHub => 'mail.example.local',
-  rootEmail => 'john.doe@example.local',
+  mailhub => 'mail.example.local',
+  rootemail => 'john.doe@example.local',
 }
 ```
 
@@ -81,15 +81,15 @@ class { '::ssmtp':
 
 The following parameters are available in the ssmtp module
 
-####`defaultMta`
+####`defaultmta`
 
 Replace the default MTA with ssmtp if set to ssmtp.
 
-####`rootEmail`
+####`rootemail`
 
 Specify which Email address should recieve all mails from root.
 
-####`mailHub`
+####`mailhub`
 
 Define the mail server which should deliver all mails.
 
@@ -107,7 +107,7 @@ The module has been tested on:
 * RedHat Enterprise Linux 5/6
 * Scientific Linux 5/6
 
-Testing on other platforms has been light and cannot be guaranteed. 
+Testing on other platforms has been light and cannot be guaranteed.
 
 
 ##Development

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,9 +12,9 @@
 #
 class ssmtp::config {
   # make parameters available in local scope for usage in templates
-  $defaultMta       = $ssmtp::defaultMta
-  $rootEmail        = $ssmtp::rootEmail
-  $mailHub          = $ssmtp::mailHub
+  $defaultmta       = $ssmtp::defaultmta
+  $rootemail        = $ssmtp::rootemail
+  $mailhub          = $ssmtp::mailhub
   $revaliases       = $ssmtp::revaliases
   $fromlineoverride = $ssmtp::fromlineoverride
   $authuser         = $ssmtp::authuser
@@ -30,20 +30,20 @@ class ssmtp::config {
 
   # sSMTP configuration
   file {
-    $ssmtp::params::configSsmtpConf:
-      ensure  => present,
+    $ssmtp::params::configssmtpconf:
+      ensure  => file,
       mode    => '0640',
       owner   => 'root',
       group   => 'mail',
-      path    => $ssmtp::params::configSsmtpConf,
-      content => template($ssmtp::params::configSsmtpConfTemplate);
+      path    => $ssmtp::params::configssmtpconf,
+      content => template($ssmtp::params::configssmtpconftemplate);
 
-    $ssmtp::params::configRevaliasesConf:
-      ensure  => present,
+    $ssmtp::params::configrevaliasesconf:
+      ensure  => file,
       mode    => '0644',
       owner   => 'root',
       group   => 'root',
-      path    => $ssmtp::params::configRevaliasesConf,
-      content => template($ssmtp::params::configRevaliasesConfTemplate);
+      path    => $ssmtp::params::configrevaliasesconf,
+      content => template($ssmtp::params::configrevaliasesconftemplate);
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,13 +6,13 @@
 #
 # Document parameters here.
 #
-# [*defaultMta*]
+# [*defaultmta*]
 #   if set to ssmtp, this class will be used
 #
-# [*rootEmail*]
+# [*rootemail*]
 #   Mail address that get root mails
 #
-# [*mailHub*]
+# [*mailhub*]
 #   server that handle outgoing mail
 #
 # [fromlineoverride]
@@ -53,8 +53,8 @@
 # === Examples
 #
 #  class { '::ssmtp':
-#    mailHub => 'mail.example.local',
-#    rootEmail => 'john.doe@example.local',
+#    mailhub => 'mail.example.local',
+#    rootemail => 'john.doe@example.local',
 #  }
 #
 # === Authors
@@ -67,9 +67,9 @@
 # Copyright 2015 Thomas Bendler
 #
 class ssmtp (
-  $defaultMta       = $ssmtp::params::defaultMta,
-  $rootEmail        = $ssmtp::params::rootEmail,
-  $mailHub          = $ssmtp::params::mailHub,
+  $defaultmta       = $ssmtp::params::defaultmta,
+  $rootemail        = $ssmtp::params::rootemail,
+  $mailhub          = $ssmtp::params::mailhub,
   $revaliases       = $ssmtp::params::revaliases,
   $fromlineoverride = $ssmtp::params::fromlineoverride,
   $authuser         = undef,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -11,5 +11,5 @@
 # Sample Usage: include ssmtp::package
 #
 class ssmtp::package {
-  package { $ssmtp::params::packageCommon: ensure => installed; }
+  package { $ssmtp::params::packagecommon: ensure => installed; }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,13 +18,13 @@ class ssmtp::params {
       $linux = true
 
       # Package definition
-      $packageCommon = 'ssmtp'
+      $packagecommon = 'ssmtp'
 
       # Config definition
-      $configSsmtpConf              = '/etc/ssmtp/ssmtp.conf'
-      $configSsmtpConfTemplate      = 'ssmtp/etc/ssmtp.conf.erb'
-      $configRevaliasesConf         = '/etc/ssmtp/revaliases'
-      $configRevaliasesConfTemplate = 'ssmtp/etc/revaliases.erb'
+      $configssmtpconf              = '/etc/ssmtp/ssmtp.conf'
+      $configssmtpconftemplate      = 'ssmtp/etc/ssmtp.conf.erb'
+      $configrevaliasesconf         = '/etc/ssmtp/revaliases'
+      $configrevaliasesconftemplate = 'ssmtp/etc/revaliases.erb'
     }
     default  : {
       $linux = false
@@ -32,9 +32,9 @@ class ssmtp::params {
   }
 
   # sSMTP definitions
-  $defaultMta       = 'none'
-  $rootEmail        = 'john.doe@example.local'
-  $mailHub          = 'mail.example.local'
+  $defaultmta       = 'none'
+  $rootemail        = 'john.doe@example.local'
+  $mailhub          = 'mail.example.local'
   $revaliases       = ['# Custom revaliases']
   $fromlineoverride = 'YES'
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,10 +13,10 @@
 class ssmtp::service {
 
   # sSMTP service configuration
-  if $ssmtp::defaultMta == 'ssmtp' {
+  if $ssmtp::defaultmta == 'ssmtp' {
     exec { 'alternatives --set mta /usr/sbin/sendmail.ssmtp':
       path   => '/bin:/sbin:/usr/bin:/usr/sbin',
-      unless => 'test /etc/alternatives/mta -ef /usr/sbin/sendmail.ssmtp'
+      unless => 'test /etc/alternatives/mta -ef /usr/sbin/sendmail.ssmtp',
     }
   }
 }

--- a/templates/etc/ssmtp.conf.erb
+++ b/templates/etc/ssmtp.conf.erb
@@ -5,8 +5,8 @@
 # managed by Puppet, local changes will be overwritten
 #
 
-root=<%= @rootEmail %>
-mailhub=<%= @mailHub %>
+root=<%= @rootemail %>
+mailhub=<%= @mailhub %>
 
 FromLineOverride=<%= @fromlineoverride %>
 


### PR DESCRIPTION
Fixes no less than 31 issues.

```
puppet-ssmtp (master) ☃  puppet-lint manifests | sort
manifests/config.pp - WARNING: ensure set to present on file resource on line 34
manifests/config.pp - WARNING: ensure set to present on file resource on line 42
manifests/config.pp - WARNING: variable contains a capital letter on line 15
manifests/config.pp - WARNING: variable contains a capital letter on line 15
manifests/config.pp - WARNING: variable contains a capital letter on line 16
manifests/config.pp - WARNING: variable contains a capital letter on line 16
manifests/config.pp - WARNING: variable contains a capital letter on line 17
manifests/config.pp - WARNING: variable contains a capital letter on line 17
manifests/config.pp - WARNING: variable contains a capital letter on line 33
manifests/config.pp - WARNING: variable contains a capital letter on line 38
manifests/config.pp - WARNING: variable contains a capital letter on line 39
manifests/config.pp - WARNING: variable contains a capital letter on line 41
manifests/config.pp - WARNING: variable contains a capital letter on line 46
manifests/config.pp - WARNING: variable contains a capital letter on line 47
manifests/init.pp - WARNING: variable contains a capital letter on line 70
manifests/init.pp - WARNING: variable contains a capital letter on line 70
manifests/init.pp - WARNING: variable contains a capital letter on line 71
manifests/init.pp - WARNING: variable contains a capital letter on line 71
manifests/init.pp - WARNING: variable contains a capital letter on line 72
manifests/init.pp - WARNING: variable contains a capital letter on line 72
manifests/package.pp - WARNING: variable contains a capital letter on line 14
manifests/params.pp - WARNING: variable contains a capital letter on line 21
manifests/params.pp - WARNING: variable contains a capital letter on line 24
manifests/params.pp - WARNING: variable contains a capital letter on line 25
manifests/params.pp - WARNING: variable contains a capital letter on line 26
manifests/params.pp - WARNING: variable contains a capital letter on line 27
manifests/params.pp - WARNING: variable contains a capital letter on line 35
manifests/params.pp - WARNING: variable contains a capital letter on line 36
manifests/params.pp - WARNING: variable contains a capital letter on line 37
manifests/service.pp - WARNING: missing trailing comma after last element on line 19
manifests/service.pp - WARNING: variable contains a capital letter on line 16
```